### PR TITLE
Travis CI caching support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ install:
 jobs:
   include:
     - script:
-      - name: "Tests"
+      env: RUNNING="Tests"
       
       # copy the currently building repo into a build_module
       - cp -r $TRAVIS_BUILD_DIR $HOME/r2d2/modules/build_module
@@ -66,7 +66,7 @@ jobs:
       - make clean
 
     - script:
-      - name: "Arduino Code"
+      env: RUNNING="Arduino Code"
 
       # copy the currently building repo into a build_module
       - cp -r $TRAVIS_BUILD_DIR $HOME/r2d2/modules/build_module

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ cache:
 
 install:
   # clone git repo to the $HOME folder
-  - git clone --recursive -j8  https://github.com/R2D2-2019/R2D2-build.git $HOME/r2d2
+  - git clone --branch travis-ci --recursive -j8  https://github.com/R2D2-2019/R2D2-build.git $HOME/r2d2
   
   # make installer executable
   - chmod +x $HOME/r2d2/programs/travis-ci/install_arm-eabi-gcc.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,8 +64,6 @@ jobs:
       - make clean
 
     - script:
-      env: RUNNING="Arduino Code"
-
       # copy the currently building repo into a build_module
       - cp -r $TRAVIS_BUILD_DIR $HOME/r2d2/modules/build_module
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,13 +28,9 @@ cache:
     # cache the arm-none-eabi location
     - $HOME/arm-none-eabi
 
-before_install:
-  # try to create the arm-none-eabi folder
-  - mkdir -p $HOME/arm-none-eabi
-
 install:
   # clone git repo to the $HOME folder
-  - git clone --branch travis-ci --recursive -j8  https://github.com/R2D2-2019/R2D2-build.git $HOME/r2d2
+  - git clone --recursive -j8  https://github.com/R2D2-2019/R2D2-build.git $HOME/r2d2
   
   # make installer executable
   - chmod +x $HOME/r2d2/programs/travis-ci/install_arm-eabi-gcc.sh
@@ -42,13 +38,16 @@ install:
   # run installer
   - $HOME/r2d2/programs/travis-ci/install_arm-eabi-gcc.sh
 
+  # add arm-eabi-gcc to path
+  - export PATH=$PATH:$HOME/arm-none-eabi/bin/ 
+
   # Change symlinks of gcc to gcc-7
-  - unlink /usr/bin/gcc && ln -s /usr/bin/gcc-7 /usr/bin/gcc 
-  - unlink /usr/bin/g++ && ln -s /usr/bin/g++-7 /usr/bin/g++  
+  - sudo unlink /usr/bin/gcc && sudo ln -s /usr/bin/gcc-7 /usr/bin/gcc 
+  - sudo unlink /usr/bin/g++ && sudo ln -s /usr/bin/g++-7 /usr/bin/g++  
 
   # link to /bin/ location
-  - ln -s /usr/bin/gcc /bin/gcc
-  - ln -s /usr/bin/g++ /bin/g++  
+  - sudo ln -s /usr/bin/gcc /bin/gcc
+  - sudo ln -s /usr/bin/g++ /bin/g++  
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ addons:
     - lib32ncurses5
     - lib32z1 
   apt:
+    sources:
+      - ubuntu-toolchain-r-test
     packages:
       - gcc-7
       - g++-7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,65 +1,80 @@
+dist: trusty
+sudo: required
 language: cpp
 
 notifications:
   email: false
   
 branches:
-    only:
-        - master
-        - release
+  only:
+    - master
+    - release
 
 addons:
-    apt_packages:
-        - lib32bz2-1.0
-        - lib32ncurses5
-        - lib32z1 
-    apt:
-        sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise 
-        packages:
-            - gcc-7
-            - g++-7
-        
-     
+  apt_packages:
+    - lib32bz2-1.0
+    - lib32ncurses5
+    - lib32z1 
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+      - llvm-toolchain-precise 
+    packages:
+      - gcc-7
+      - g++-7
 
-before_script:
-    - wget  https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compilers/GCC%208.3.0/Raspberry%20Pi%202%2C%203/cross-gcc-8.3.0-pi_2-3.tar.gz/download
-    - tar xf download
-    - sudo mv cross-pi-gcc-8.3.0-1 /opt
-    - echo 'export PATH=/opt/cross-pi-gcc-8.3.0-1/bin:$PATH' >> .profile  
-    - echo 'export LD_LIBRARY_PATH=/opt/cross-pi-gcc-8.3.0-1/lib:$LD_LIBRARY_PATH' >> .profile
-    - source .profile
-    - arm-linux-gnueabihf-g++ -v
-    - g++ -v
-    - gcc -v
+cache:
+  directories:
+    # cache the arm-none-eabi location
+    - $HOME/arm-none-eabi
+
+before_install:
+  # try to create the arm-none-eabi folder
+  - mkdir -p $HOME/arm-none-eabi
 
 install:
-    - cd ..
-    - git clone https://github.com/R2D2-2019/R2D2-build.git
-    - cd R2D2-build
-    - git submodule update --init --recursive
-    - cd ..    
-    - sudo unlink /usr/bin/gcc && sudo ln -s /usr/bin/gcc-7 /usr/bin/gcc # Change symlinks of gcc to gcc-7
-    - sudo unlink /usr/bin/g++ && sudo ln -s /usr/bin/g++-7 /usr/bin/g++
-    - export PATH=$PATH:/usr/bin/g++:/usr/bin/gcc
-    - sudo cp -r /usr/bin/gcc /bin/gcc
-    - sudo cp -r /usr/bin/g++ /bin/g++
-    
-    
+  # clone git repo to the $HOME folder
+  - git clone --branch travis-ci --recursive -j8  https://github.com/R2D2-2019/R2D2-build.git $HOME/r2d2
+  
+  # make installer executable
+  - chmod +x $HOME/r2d2/programs/travis-ci/install_arm-eabi-gcc.sh
+
+  # run installer
+  - $HOME/r2d2/programs/travis-ci/install_arm-eabi-gcc.sh
+
+  # Change symlinks of gcc to gcc-7
+  - unlink /usr/bin/gcc && ln -s /usr/bin/gcc-7 /usr/bin/gcc 
+  - unlink /usr/bin/g++ && ln -s /usr/bin/g++-7 /usr/bin/g++  
+
+  # link to /bin/ location
+  - ln -s /usr/bin/gcc /bin/gcc
+  - ln -s /usr/bin/g++ /bin/g++  
+
 jobs:
-    include:
-        - script:
-            - cd R2D2-build/modules
-            - cp -r $TRAVIS_BUILD_DIR $PWD/test_module
-            - cd test_module/test
-            - make build 
-            - make run
-            - make clean
-        - script:
-            - cd R2D2-build/modules
-            - cp -r $TRAVIS_BUILD_DIR $PWD/test_module
-            - cd test_module/code
-            - make build
-            - make clean
-        
+  include:
+    - script:
+      - name: "Tests"
+      
+      # copy the currently building repo into a build_module
+      - cp -r $TRAVIS_BUILD_DIR $HOME/r2d2/modules/build_module
+
+      # go into the modules folder of the build system
+      - cd $HOME/r2d2/modules/build_module/test
+
+      # build the module
+      - make build 
+      - make run
+      - make clean
+
+    - script:
+      - name: "Arduino Code"
+
+      # copy the currently building repo into a build_module
+      - cp -r $TRAVIS_BUILD_DIR $HOME/r2d2/modules/build_module
+
+      # go into the modules folder of the build system
+      - cd $HOME/r2d2/modules/build_module/code
+
+      # build the module
+      - make build
+      - make clean

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,8 +52,6 @@ install:
 jobs:
   include:
     - script:
-      env: RUNNING="Tests"
-      
       # copy the currently building repo into a build_module
       - cp -r $TRAVIS_BUILD_DIR $HOME/r2d2/modules/build_module
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
+      - llvm-toolchain-precise
     packages:
       - gcc-7
       - g++-7

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,6 @@ addons:
     - lib32ncurses5
     - lib32z1 
   apt:
-    sources:
-      - ubuntu-toolchain-r-test
-      - llvm-toolchain-precise 
     packages:
       - gcc-7
       - g++-7

--- a/code/Makefile
+++ b/code/Makefile
@@ -20,5 +20,5 @@ SEARCH  := ./headers ./src
 # set REATIVE to the next higher directory 
 # and defer to the Makefile.due there
 RELATIVE := $(RELATIVE)../
-include $(RELATIVE)Makefile.pi
+include $(RELATIVE)Makefile.due
 

--- a/code/main.cpp
+++ b/code/main.cpp
@@ -1,18 +1,11 @@
-#include <iostream>
 #include <hwlib.hpp>
 
 int main(void) {
-    hwlib::target::init();  
-    std::cout << "Raspberry Pi blink\n";
-
-    auto led = hwlib::target::pin_out(hwlib::target::pins::d40);
-
-    while (true) {
-        led.write(true); // on
-        hwlib::wait_ms(500);
-        led.write(false); // on
-        hwlib::wait_ms(500);
+  // kill the watchdog
+    WDT->WDT_MR = WDT_MR_WDDIS;
+    hwlib::wait_ms(1000);
+    for (;;){
+        hwlib::cout << "this works via arduino";
+        hwlib::wait_ms(1000);
     }
-
-    return 0;
 }


### PR DESCRIPTION
This arduino due .travis.yml example is found on https://github.com/R2D2-2019/R2D2-build/blob/travis-ci/programs/travis-ci/example_due.travis.yml

This needs to be updated to the normal r2d2-build branch